### PR TITLE
Improvement: Fix id size for TimeStampedModel

### DIFF
--- a/core/apps/common/models.py
+++ b/core/apps/common/models.py
@@ -3,7 +3,7 @@ from django.utils import timezone
 
 
 class TimeStampedModel(models.Model):
-    id = models.UUIDField(max_length=180, primary_key=True)
+    id = models.UUIDField(max_length=34, primary_key=True)
     created = models.DateTimeField(default=timezone.now, editable=False, db_index=True)
     modified = models.DateTimeField(auto_now=True)
 


### PR DESCRIPTION
This PR fixes the id length for timestampedmodel

- [x] fix max_length for id for timestampedmodel